### PR TITLE
Implement relations and transactions

### DIFF
--- a/dialects/neo4j.go
+++ b/dialects/neo4j.go
@@ -514,12 +514,12 @@ func (n *Neo4jRuntime) Rollback() error {
 }
 
 func (n *Neo4jRuntime) BeginTransaction() error {
-	t, err := (*n.session).BeginTransaction()
+	tx, err := (*n.session).BeginTransaction()
 	if err != nil {
 		return err
 	}
 
-	n.transaction = &t
+	n.transaction = &tx
 	return nil
 }
 

--- a/dialects/neo4j.go
+++ b/dialects/neo4j.go
@@ -79,9 +79,8 @@ func (n *Neo4jRuntime) CheckForInjection(expStr string) (uint, bool) {
 }
 
 func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
-	targetAction := ""
-	className := ""
-	nodeName := ""
+	kvp := make(map[string]string)
+	kvp["Context.Find"] = "Self"
 	queryBody := ""
 
 	for _, op := range *cradle.Ops.GetAll() {
@@ -91,57 +90,53 @@ func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			className = exp.(string)
+			kvp["className"] = exp.(string)
+			break
 		case e.SetTarget:
-			targetAction = "MATCH"
-			if reflect.TypeOf(cradle.Out).Kind() == reflect.Ptr {
-				if reflect.TypeOf(cradle.Out).Elem().Kind() == reflect.Struct {
-					className = reflect.TypeOf(cradle.Out).Elem().Name()
-				} else if reflect.TypeOf(cradle.Out).Elem().Kind() == reflect.Slice &&
-					reflect.TypeOf(cradle.Out).Elem().Elem().Kind() == reflect.Struct {
-					className = reflect.TypeOf(cradle.Out).Elem().Elem().Name()
-				}
-			} else if reflect.TypeOf(cradle.Out).Kind() == reflect.Struct {
-				className = reflect.TypeOf(cradle.Out).Name()
+			kvp["className"] = e.GetTypeName(cradle.Out)
+
+			if _, ok := kvp["nodeName"]; !ok {
+				kvp["nodeName"] = "n"
 			}
 
-			if nodeName == "" {
-				nodeName = "n"
+			if kvp["Context.Find"] == "Self" {
+				exp := e.Marshal(cradle.Out)
+				e.SanitizeExp(exp)
+				queryBody = n.marshalToCypherExp(exp)
+				return fmt.Sprintf("MATCH (%s: %s {%s}) RETURN {result: %s}", kvp["nodeName"],
+					kvp["className"], queryBody, kvp["nodeName"]), nil
+			} else if kvp["Context.Find"] == "Where" {
+				genQuery := fmt.Sprintf("MATCH (%s: %s) %s RETURN {result: %s}", kvp["nodeName"],
+					kvp["className"], queryBody, kvp["nodeName"])
+				genQuery = n.prefixNodeName(genQuery, kvp["nodeName"])
+				return genQuery, nil
+			} else if kvp["Context.Find"] == "Relation" {
+				genQuery := fmt.Sprintf("MATCH (n: %s {%s})-[:%s]->(m: %s) RETURN {result: m}", kvp["classNameX"],
+					kvp["cypherA"], kvp["relName"], kvp["className"])
+				return genQuery, nil
 			}
 
-			if queryBody == "" {
-				exp, err := cradle.Exps.Get()
-				if err != nil {
-					return "", err
-				}
-				queryBody = n.marshalToCypherExp(exp.(e.Exp))
-				return fmt.Sprintf("MATCH (%s: %s {%s}) RETURN {result: %s}", nodeName, className, queryBody, nodeName), nil
-			}
-
-			genQuery := fmt.Sprintf("%s (%s: %s) %s RETURN {result: %s}", targetAction, nodeName, className, queryBody, nodeName)
-			genQuery = n.prefixNodeName(genQuery, nodeName)
-			return genQuery, nil
 		case e.Creation:
 			if reflect.TypeOf(cradle.Out).Kind() == reflect.Ptr {
 				if reflect.TypeOf(cradle.Out).Elem().Kind() == reflect.Struct {
-					className = reflect.TypeOf(cradle.Out).Elem().Name()
+					kvp["className"] = reflect.TypeOf(cradle.Out).Elem().Name()
 				} else if reflect.TypeOf(cradle.Out).Elem().Kind() == reflect.Slice &&
 					reflect.TypeOf(cradle.Out).Elem().Elem().Kind() == reflect.Struct {
-					className = reflect.TypeOf(cradle.Out).Elem().Elem().Name()
+					kvp["className"] = reflect.TypeOf(cradle.Out).Elem().Elem().Name()
 				}
 			} else if reflect.TypeOf(cradle.Out).Kind() == reflect.Struct {
-				className = reflect.TypeOf(cradle.Out).Name()
+				kvp["className"] = reflect.TypeOf(cradle.Out).Name()
 			}
 
-			if nodeName == "" {
-				nodeName = "n"
+			if _, ok := kvp["nodeName"]; !ok {
+				kvp["nodeName"] = "n"
 			}
 
 			exp, err := cradle.Exps.Get()
 			if err != nil {
 				return "", err
 			}
-			genQuery := fmt.Sprintf("CREATE (%s:%s {%s})", nodeName, className, n.marshalToCypherExp(exp.(e.Exp)))
+			genQuery := fmt.Sprintf("CREATE (%s:%s {%s})", kvp["nodeName"], kvp["className"], n.marshalToCypherExp(exp.(e.Exp)))
 			return genQuery, nil
 		case e.Where:
 			queryBody = "WHERE"
@@ -151,6 +146,9 @@ func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
 			}
 
 			queryBody = queryBody + " " + expression.(string)
+			kvp["Context.Find"] = "Where"
+
+			break
 		case e.And:
 			queryBody += " and"
 			expression, err := cradle.Exps.Get()
@@ -158,6 +156,7 @@ func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
 				return "", err
 			}
 			queryBody = queryBody + " " + expression.(string)
+			break
 		case e.Or:
 			queryBody += " or"
 			expression, err := cradle.Exps.Get()
@@ -165,27 +164,22 @@ func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
 				return "", err
 			}
 			queryBody = queryBody + " " + expression.(string)
-		case e.MiscNodeName:
-			expression, err := cradle.Exps.Get()
-			if err != nil {
-				return "", err
-			}
-			nodeName = expression.(string)
+			break
 		case e.Updation:
 
 			if reflect.TypeOf(cradle.Out).Kind() == reflect.Ptr {
 				if reflect.TypeOf(cradle.Out).Elem().Kind() == reflect.Struct {
-					className = reflect.TypeOf(cradle.Out).Elem().Name()
+					kvp["className"] = reflect.TypeOf(cradle.Out).Elem().Name()
 				} else if reflect.TypeOf(cradle.Out).Elem().Kind() == reflect.Slice &&
 					reflect.TypeOf(cradle.Out).Elem().Elem().Kind() == reflect.Struct {
-					className = reflect.TypeOf(cradle.Out).Elem().Elem().Name()
+					kvp["className"] = reflect.TypeOf(cradle.Out).Elem().Elem().Name()
 				}
 			} else if reflect.TypeOf(cradle.Out).Kind() == reflect.Struct {
-				className = reflect.TypeOf(cradle.Out).Name()
+				kvp["className"] = reflect.TypeOf(cradle.Out).Name()
 			}
 
-			if nodeName == "" {
-				nodeName = "n"
+			if _, ok := kvp["nodeName"]; !ok {
+				kvp["nodeName"] = "n"
 			}
 
 			exp, err := cradle.Exps.Get()
@@ -196,23 +190,25 @@ func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
 
 			genQuery := ""
 			if queryBody != "" {
-				queryBody = n.prefixNodeName(queryBody, nodeName)
-				genQuery = fmt.Sprintf("MATCH (%s: %s) %s SET %s = {%s} RETURN {result: %s}", nodeName, className, queryBody, nodeName,
-					n.prefixNodeName(n.marshalToCypherExp(exp.(e.Exp)), nodeName), nodeName)
+				queryBody = n.prefixNodeName(queryBody, kvp["nodeName"])
+				genQuery = fmt.Sprintf("MATCH (%s: %s) %s SET %s = {%s} RETURN {result: %s}", kvp["nodeName"], kvp["className"],
+					queryBody, kvp["nodeName"],
+					n.prefixNodeName(n.marshalToCypherExp(exp.(e.Exp)), kvp["nodeName"]), kvp["nodeName"])
 			} else {
 				// We haven't encountered a where clause yet. So fetch search params from cradle.out
 				marsh := e.Marshal(cradle.Out)
 				e.SanitizeExp(marsh)
 				cypherA := n.marshalToCypherExp(marsh)
-				genQuery = fmt.Sprintf("MATCH (%s: %s {%s}) SET %s = {%s} RETURN {result: %s}", nodeName, className, cypherA,
-					nodeName, n.prefixNodeName(n.marshalToCypherExp(exp.(e.Exp)), nodeName), nodeName)
+				genQuery = fmt.Sprintf("MATCH (%s: %s {%s}) SET %s = {%s} RETURN {result: %s}", kvp["nodeName"], kvp["className"],
+					cypherA,
+					kvp["nodeName"], n.prefixNodeName(n.marshalToCypherExp(exp.(e.Exp)), kvp["nodeName"]), kvp["nodeName"])
 			}
 
 			return genQuery, nil
 		case e.UpdationStr:
 
-			if nodeName == "" {
-				nodeName = "n"
+			if _, ok := kvp["nodeName"]; !ok {
+				kvp["nodeName"] = "n"
 			}
 
 			exp, err := cradle.Exps.Get()
@@ -225,9 +221,10 @@ func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
 
 			// If queryBody is non-empty this means that we have encountered a where clause.
 			if queryBody != "" {
-				queryBody = n.prefixNodeName(queryBody, nodeName)
-				genQuery = fmt.Sprintf("MATCH (%s: %s) %s SET %s RETURN {result: %s}", nodeName, className, queryBody,
-					n.prefixNodeName(exp.(string), nodeName), nodeName)
+				queryBody = n.prefixNodeName(queryBody, kvp["nodeName"])
+				genQuery = fmt.Sprintf("MATCH (%s: %s) %s SET %s RETURN {result: %s}", kvp["nodeName"], kvp["className"],
+					queryBody,
+					n.prefixNodeName(exp.(string), kvp["nodeName"]), kvp["nodeName"])
 			} else {
 				// We haven't encountered a where clause yet. So fetch search params from cradle.out
 				marsh := e.Marshal(cradle.Out)
@@ -237,25 +234,26 @@ func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
 				if reflect.TypeOf(cradle.Out).Kind() == reflect.Ptr &&
 					reflect.TypeOf(cradle.Out).Elem().Kind() == reflect.Struct {
 
-					className = reflect.TypeOf(cradle.Out).Elem().Name()
+					kvp["className"] = reflect.TypeOf(cradle.Out).Elem().Name()
 				} else if reflect.TypeOf(cradle.Out).Kind() == reflect.Struct {
-					className = reflect.TypeOf(cradle.Out).Name()
+					kvp["className"] = reflect.TypeOf(cradle.Out).Name()
 				}
 
-				genQuery = fmt.Sprintf("MATCH (%s: %s {%s}) SET %s RETURN {result: %s}", nodeName, className, cypherA,
-					n.prefixNodeName(exp.(string), nodeName), nodeName)
+				genQuery = fmt.Sprintf("MATCH (%s: %s {%s}) SET %s RETURN {result: %s}", kvp["nodeName"],
+					kvp["className"], cypherA,
+					n.prefixNodeName(exp.(string), kvp["nodeName"]), kvp["nodeName"])
 			}
 
 			return genQuery, nil
 		case e.Deletion:
 			genQuery := ""
-			if nodeName == "" {
-				nodeName = "n"
+			if _, ok := kvp["nodeName"]; !ok {
+				kvp["nodeName"] = "n"
 			}
 			if queryBody != "" {
-				genQuery = fmt.Sprintf("MATCH (%s: %s) %s DETACH DELETE %s", nodeName, className, queryBody,
-					nodeName)
-				genQuery = n.prefixNodeName(genQuery, nodeName)
+				genQuery = fmt.Sprintf("MATCH (%s: %s) %s DETACH DELETE %s", kvp["nodeName"], kvp["className"],
+					queryBody, kvp["nodeName"])
+				genQuery = n.prefixNodeName(genQuery, kvp["nodeName"])
 			} else {
 				// We haven't encountered a where clause yet. So fetch search params from cradle.out
 				marsh := e.Marshal(cradle.Out)
@@ -265,15 +263,89 @@ func (n *Neo4jRuntime) Compile(cradle *e.QueryCradle) (string, error) {
 				if reflect.TypeOf(cradle.Out).Kind() == reflect.Ptr &&
 					reflect.TypeOf(cradle.Out).Elem().Kind() == reflect.Struct {
 
-					className = reflect.TypeOf(cradle.Out).Elem().Name()
+					kvp["className"] = reflect.TypeOf(cradle.Out).Elem().Name()
 				} else if reflect.TypeOf(cradle.Out).Kind() == reflect.Struct {
-					className = reflect.TypeOf(cradle.Out).Name()
+					kvp["className"] = reflect.TypeOf(cradle.Out).Name()
 				}
 
-				genQuery = fmt.Sprintf("MATCH (%s: %s {%s}) DETACH DELETE %s", nodeName, className, cypherA, nodeName)
+				genQuery = fmt.Sprintf("MATCH (%s: %s {%s}) DETACH DELETE %s", kvp["nodeName"], kvp["className"],
+					cypherA, kvp["nodeName"])
 			}
 
 			return genQuery, nil
+		case e.RelationX:
+			exp, err := cradle.Exps.Get()
+			if err != nil {
+				return "", err
+			}
+
+			if reflect.TypeOf(exp).Kind() == reflect.Ptr {
+				if reflect.TypeOf(exp).Elem().Kind() == reflect.Struct {
+					kvp["classNameX"] = reflect.TypeOf(exp).Elem().Name()
+				} else if reflect.TypeOf(exp).Elem().Kind() == reflect.Slice &&
+					reflect.TypeOf(exp).Elem().Elem().Kind() == reflect.Struct {
+					return "", e.Error(e.ExpectedStructNotSlice)
+				}
+			} else if reflect.TypeOf(exp).Kind() == reflect.Struct {
+				kvp["classNameX"] = reflect.TypeOf(exp).Name()
+			}
+
+
+			lucyExp := e.Marshal(exp)
+			e.SanitizeExp(lucyExp)
+
+			kvp["matchExpX"] = n.marshalToCypherExp(lucyExp)
+		case e.RelationY:
+			exp, err := cradle.Exps.Get()
+			if err != nil {
+				return "", err
+			}
+
+			if reflect.TypeOf(exp).Kind() == reflect.Ptr {
+				if reflect.TypeOf(exp).Elem().Kind() == reflect.Struct {
+					kvp["classNameY"] = reflect.TypeOf(exp).Elem().Name()
+				} else if reflect.TypeOf(exp).Elem().Kind() == reflect.Slice &&
+					reflect.TypeOf(exp).Elem().Elem().Kind() == reflect.Struct {
+					return "", e.Error(e.ExpectedStructNotSlice)
+				}
+			} else if reflect.TypeOf(exp).Kind() == reflect.Struct {
+				kvp["classNameY"] = reflect.TypeOf(exp).Name()
+			}
+
+			lucyExp := e.Marshal(exp)
+			e.SanitizeExp(lucyExp)
+
+			kvp["matchExpY"] = n.marshalToCypherExp(lucyExp)
+		case e.By:
+			exp, err := cradle.Exps.Get()
+			if err != nil {
+				return "", err
+			}
+
+			relName := exp.(string)
+			genQuery := fmt.Sprintf("MATCH (n: %s {%s}), (m: %s {%s}) CREATE (n)-[:%s]->(m)", kvp["classNameX"],
+				kvp["matchExpX"], kvp["classNameY"], kvp["matchExpY"], relName)
+			return genQuery, nil
+		case e.MTRelation:
+			kvp["Context.Find"] = "Relation"
+
+			exp, err := cradle.Exps.Get()
+			if err != nil {
+				return "", err
+			}
+
+			pExp := exp.(e.Exp)
+
+
+			kvp["classNameX"] = e.GetTypeName(pExp["out"])
+
+			outExp := e.Marshal(pExp["out"])
+			e.SanitizeExp(outExp)
+			kvp["cypherA"] = n.marshalToCypherExp(outExp)
+			kvp["relName"] = pExp["relation"].(string)
+
+			fmt.Println(kvp["classNameX"])
+			break
 		}
 	}
 

--- a/internal/database.go
+++ b/internal/database.go
@@ -97,16 +97,6 @@ func (l *Database) Or(I_ interface{}, I ...interface{}) *Database {
 	return l
 }
 
-func (l *Database) By(name string) *Database {
-	if l.Error != nil {
-		return l
-	}
-
-	l.addQuery(Query{FamilyType: MiscNodeName, Params: name})
-
-	return l
-}
-
 func (l *Database) Set(I_ interface{}, I ...interface{}) *Database {
 	if l.Error != nil {
 		return l
@@ -154,8 +144,42 @@ func (l *Database) Delete() *Database {
 	return l
 }
 
-func (l *Database) Begin() *Database {
-	l.layer.StartTransaction()
+func (l *Database) Relate(I interface{}) *Database {
+	if l.Error != nil {
+		return l
+	}
+
+	l.addQuery(Query{FamilyType: RelationX, Params: I})
+	return l
+}
+
+func (l *Database) To(I interface{}) *Database {
+	if l.Error != nil {
+		return l
+	}
+
+	l.addQuery(Query{FamilyType: RelationY, Params: I})
+	return l
+}
+
+func (l *Database) By(relName string) *Database {
+	if l.Error != nil {
+		return l
+	}
+
+	l.addQuery(Query{FamilyType: By, Params: relName})
+	l.Error = l.layer.Sync()
+
+	return l
+}
+
+func (l *Database) Relation(relName string) *Database {
+	if l.Error != nil {
+		return l
+	}
+
+	l.addQuery(Query{FamilyType:MTRelation, Params: Exp{"relation": relName}})
+
 	return l
 }
 

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -9,6 +9,8 @@ const (
 	QueryInjection
 	NoRecordsFound
 	ExpectedStructNotSlice
+	ArgumentMismatch
+	InvalidOperation
 )
 
 const (
@@ -39,6 +41,8 @@ func (e *LucyErrors) Init() *LucyErrors {
 		QueryInjection:         "lucy: query injection detected",
 		NoRecordsFound:         "lucy: No records found",
 		ExpectedStructNotSlice: "lucy: Expected struct but found slice",
+		ArgumentMismatch:       "lucy: Argument mismatch",
+		InvalidOperation:       "lucy: Invalid operation",
 	}
 	return e
 }

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -8,6 +8,7 @@ const (
 	UnrecognizedExpression
 	QueryInjection
 	NoRecordsFound
+	ExpectedStructNotSlice
 )
 
 const (
@@ -37,6 +38,7 @@ func (e *LucyErrors) Init() *LucyErrors {
 		UnrecognizedExpression: "lucy: expression not recognized",
 		QueryInjection:         "lucy: query injection detected",
 		NoRecordsFound:         "lucy: No records found",
+		ExpectedStructNotSlice: "lucy: Expected struct but found slice",
 	}
 	return e
 }

--- a/internal/family.go
+++ b/internal/family.go
@@ -4,7 +4,8 @@ type FamilyType uint
 
 const (
 	Where FamilyType = iota
-	Relation
+	RelationX
+	RelationY
 	Creation
 	Updation
 	UpdationStr
@@ -13,6 +14,7 @@ const (
 	Unknown
 	And
 	Or
-	MiscNodeName
+	By
 	Model
+	MTRelation
 )

--- a/internal/query_engine.go
+++ b/internal/query_engine.go
@@ -1,6 +1,7 @@
 package lucy
 
 import (
+	"fmt"
 	"github.com/supercmmetry/lucy/types"
 	"reflect"
 )
@@ -290,7 +291,7 @@ func (q *QueryEngine) Sync() error {
 		return err
 	}
 
-	// fmt.Println("Generated query: ", query)
+	fmt.Println("Generated query: ", query)
 
 	if err := q.Runtime.Execute(query, q.cradle, q.cradle.Out); err != nil {
 		q.cradle.init()

--- a/internal/query_engine.go
+++ b/internal/query_engine.go
@@ -1,6 +1,7 @@
 package lucy
 
 import (
+	"github.com/supercmmetry/lucy/types"
 	"reflect"
 )
 
@@ -169,7 +170,7 @@ func (q *QueryEngine) Sync() error {
 		case Creation:
 			cradle.Ops.Push(cradle.family)
 
-			exp := qr.Params.(Exp)
+			exp := qr.Params.(types.Exp)
 			for k, v := range exp {
 				exp[k] = Format("?", v)
 			}
@@ -190,7 +191,7 @@ func (q *QueryEngine) Sync() error {
 
 			cradle.Ops.Push(cradle.family)
 
-			exp := qr.Params.(Exp)
+			exp := qr.Params.(types.Exp)
 			for k, v := range exp {
 				exp[k] = Format("?", v)
 			}
@@ -272,7 +273,7 @@ func (q *QueryEngine) Sync() error {
 
 			cradle.Ops.Push(cradle.family)
 
-			exp := qr.Params.(Exp)
+			exp := qr.Params.(types.Exp)
 			exp["out"] = cradle.Out
 			cradle.Exps.Push(exp)
 

--- a/internal/query_engine.go
+++ b/internal/query_engine.go
@@ -1,7 +1,6 @@
 package lucy
 
 import (
-	"fmt"
 	"reflect"
 )
 
@@ -37,6 +36,11 @@ type QueryRuntime interface {
 	Compile(cradle *QueryCradle) (string, error)
 	Execute(query string, cradle *QueryCradle, target interface{}) error
 	Close() error
+	Commit() error
+	Rollback() error
+	BeginTransaction() error
+	CloseTransaction() error
+	Clone() QueryRuntime
 }
 
 /*
@@ -152,7 +156,6 @@ func (q *QueryEngine) Sync() error {
 
 			cradle.Exps.Push(param)
 			cradle.Ops.Push(cradle.family)
-
 
 			break
 		case SetTarget:
@@ -286,7 +289,7 @@ func (q *QueryEngine) Sync() error {
 		return err
 	}
 
-	fmt.Println("Generated query: ", query)
+	// fmt.Println("Generated query: ", query)
 
 	if err := q.Runtime.Execute(query, q.cradle, q.cradle.Out); err != nil {
 		q.cradle.init()

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,13 +2,13 @@ package lucy
 
 import (
 	"fmt"
+	"github.com/supercmmetry/lucy/types"
 	"reflect"
 	"strconv"
 )
 
-type Exp map[string]interface{}
 
-func Marshal(v interface{}) Exp {
+func Marshal(v interface{}) types.Exp {
 	vtype := reflect.TypeOf(v)
 	vvalue := reflect.ValueOf(v)
 
@@ -168,7 +168,7 @@ func Format(format string, I ...interface{}) string {
 	return SFormat(format, I)
 }
 
-func SanitizeExp(exp Exp) {
+func SanitizeExp(exp types.Exp) {
 	for k, v := range exp {
 		exp[k] = Format("?", v)
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -168,10 +168,24 @@ func Format(format string, I ...interface{}) string {
 	return SFormat(format, I)
 }
 
-func SanitizeExp(exp Exp){
+func SanitizeExp(exp Exp) {
 	for k, v := range exp {
 		exp[k] = Format("?", v)
 	}
+}
+
+func GetTypeName(i interface{}) string {
+	if reflect.TypeOf(i).Kind() == reflect.Ptr {
+		if reflect.TypeOf(i).Elem().Kind() == reflect.Struct {
+			return reflect.TypeOf(i).Elem().Name()
+		} else if reflect.TypeOf(i).Elem().Kind() == reflect.Slice &&
+			reflect.TypeOf(i).Elem().Elem().Kind() == reflect.Struct {
+			return reflect.TypeOf(i).Elem().Elem().Name()
+		}
+	} else if reflect.TypeOf(i).Kind() == reflect.Struct {
+		return reflect.TypeOf(i).Name()
+	}
+	return ""
 }
 
 type Queue struct {

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func main() {
 	fmt.Println("DscDevelopers in LEARNS_FROM.Y: ", relPeeps)
 
 	tx.Commit()
+	tx.Close()
 
 	err = db.Error
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -105,7 +105,6 @@ func main() {
 	fmt.Println("DscDevelopers in LEARNS_FROM.Y: ", relPeeps)
 
 	tx.Commit()
-	tx.Close()
 
 	err = db.Error
 	if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,3 @@
+package types
+
+type Exp map[string]interface{}


### PR DESCRIPTION
- Create one-to-one relations over multi-target.
- Capture one-to-many relations.
- Implement transactions with non-redundant syntax.
- Automatically create a new QueryRuntime instance for each transaction.
- Preserve session while creating transactions.
- Add support for bidirectional relations
- Add support for relations holding data